### PR TITLE
ci: add python CI workflow with ruff checks

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,94 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Python CI checks"
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.py"
+      - "**/requirements.txt"
+      - .github/workflows/python-ci.yml
+  push:
+    branches:
+      - main
+    paths:
+      - "**.py"
+      - "**/requirements.txt"
+      - .github/workflows/python-ci.yml
+
+jobs:
+  discover-projects:
+    name: Discover Python Projects
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.resolve.outputs.projects }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed files
+        id: changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          dir_names: true
+          files_yaml: |
+            python:
+              - '**.py'
+              - '**/requirements.txt'
+            workflow:
+              - .github/workflows/python-ci.yml
+      - name: Resolve affected Python projects
+        id: resolve
+        env:
+          CHANGED_DIRS: ${{ steps.changed.outputs.python_all_changed_files }}
+          WORKFLOW_CHANGED: ${{ steps.changed.outputs.workflow_any_changed }}
+        run: |
+          if [[ "$WORKFLOW_CHANGED" == "true" ]]; then
+            # Workflow file changed, need check all projects
+            projects=$(find . -name requirements.txt -exec dirname {} \; | jq -Rnc '[inputs]')
+          else
+            # Only collect projects containing changed files
+            projects=$(for d in $CHANGED_DIRS; do
+              while [[ "$d" != "." && ! -f "$d/requirements.txt" ]]; do d=$(dirname "$d"); done
+              [[ -f "$d/requirements.txt" ]] && echo "$d"
+            done | sort -u | jq -Rnc '[inputs]')
+          fi
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
+
+  python-checks:
+    name: Run Python Checks
+    needs: discover-projects
+    if: ${{ needs.discover-projects.outputs.projects != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.discover-projects.outputs.projects) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Ruff format check
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
+        with:
+          args: format --check
+          src: ${{ matrix.project }}
+      - name: Ruff check
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
+        with:
+          args: check
+          src: ${{ matrix.project }}


### PR DESCRIPTION
related to: https://github.com/GoogleCloudPlatform/secops-toolkit/issues/86

this an example of a possible pipeline; the checks will fail since the code isn't compliant to ruff/python standards