### PR TITLE
Fix pull all parsers CLI command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "workbench.colorTheme": "YARA-L Theme"
-}

--- a/pipelines/parsers-as-code/README.md
+++ b/pipelines/parsers-as-code/README.md
@@ -139,7 +139,7 @@ parsers/MY_CUSTOM_PARSER/
 **Workflow:**
 1. Write parser code in `parser.conf`
 2. Add sample logs to `logs/`
-3. Generate events: `python3 script/main.py generate-events --parser MY_CUSTOM_PARSER`
+3. Generate events: `python3 script/main.py generate-events --log-type MY_CUSTOM_PARSER`
 4. Commit changes and create PR
 5. Pipeline validates, submits, and (after merge) activates
 
@@ -167,7 +167,7 @@ parsers/MY_PREBUILT_PARSER/
 **Workflow:**
 1. Write extension code in `parser_extension.conf`
 2. Add sample logs to `logs/`
-3. Generate events: `python3 script/main.py generate-events --parser MY_PREBUILT_PARSER`
+3. Generate events: `python3 script/main.py generate-events --log-type MY_PREBUILT_PARSER`
    - The script automatically fetches the PREBUILT parser from Chronicle for validation
 4. Commit changes and create PR
 5. Pipeline validates extension output, submits extension, and (after merge) activates
@@ -276,7 +276,7 @@ The `main.py` script uses [Click](https://click.palletsprojects.com/) for its co
     ```
   To generate events for only one specific parser:
     ```bash
-    python3 script/main.py generate-events --parser <LOG_TYPE_NAME>
+    python3 script/main.py generate-events --log-type <LOG_TYPE_NAME>
     ```
 
   **What it does:**
@@ -503,4 +503,4 @@ Role: roles/chronicle.admin (easiest) or a custom role with the following permis
 ## License
 
 Copyright 2026 Google. This software is provided as-is, without warranty or representation for any use or purpose. Your
-use of it is subject to your agreement with Google.  
+use of it is subject to your agreement with Google.

--- a/pipelines/parsers-as-code/script/parser_manager.py
+++ b/pipelines/parsers-as-code/script/parser_manager.py
@@ -578,10 +578,8 @@ class ParserManager:
         try:
             # List all parsers with pagination
             all_parsers = []
-            response = self.client.list_parsers(
-                log_type="-", page_size=1000, page_token=None
-            )
-            all_parsers.extend(response["parsers"])
+            response = self.client.list_parsers()
+            all_parsers.extend(response)
 
             log_types = set()
             for p in all_parsers:


### PR DESCRIPTION
I ran into this error when trying to run the `pull-parsers` command:

```
(.venv) parsers[main] $ python3 script/main.py pull-parsers
2026-07-02 10:16:13,283 - parser_manager - INFO - SecOps client initialized successfully.
2026-07-02 10:16:13,283 - pac - INFO - Starting bulk pull of all parsers...
2026-07-02 10:16:13,283 - parser_manager - INFO - Discovering all parsers in the tenant...
2026-07-02 10:16:17,911 - pac - ERROR - Failed to pull parsers: Failed to list all parsers: list indices must be integers or slices, not str
Traceback (most recent call last):
  File "/Users/itse/workspace/Etsy/detection-wardrobe/parsers/script/parser_manager.py", line 584, in pull_all_parsers
    LOGGER.info(response["parsers"])
                ~~~~~~~~^^^^^^^^^^^
TypeError: list indices must be integers or slices, not str

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/itse/workspace/Etsy/detection-wardrobe/parsers/script/main.py", line 171, in pull_parsers
    manager.pull_all_parsers()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/itse/workspace/Etsy/detection-wardrobe/parsers/script/parser_manager.py", line 606, in pull_all_parsers
    raise ParserError(f"Failed to list all parsers: {e}")
models.ParserError: Failed to list all parsers: list indices must be integers or slices, not str
```

Looks like from https://github.com/google/secops-wrapper/commit/c75e13881ff5b903d0c4335431815355e5eaa78d#diff-41f5b0825a1b115ffcda07881bb1b11e59949aa4e97ed01f1a5e6c11ab0cf306, we are now returning a list of items instead of metadata. At first, I was going to add a `as_list=False` method parameter but then stepping back, shouldn't we attempt to fetch all the parsers? So I went ahead and removed pagination. But let me know if my assumption is incorrect and we should go the `as_list=False` route. `log_type` also defaults to `-` so I removed it too.

Also, I removed the vscode setting since I think it was mistakenly added.