### PR TITLE
fix: activate-parsers command should handle pparser w/o extensions

### DIFF
--- a/pipelines/parsers-as-code/script/parser_manager.py
+++ b/pipelines/parsers-as-code/script/parser_manager.py
@@ -433,24 +433,25 @@ class ParserManager:
                         break  # Assume only one valid release candidate
 
             # Activate Parser Extension
-            exts_response = self.client.list_parser_extensions(config.log_type)
-            if "parserExtensions" in exts_response:
-                for ext in exts_response["parserExtensions"]:
-                    if ext.get("state") == ParserExtensionState.VALIDATED.value:
-                        ext_content = base64.b64decode(ext["cbnSnippet"]).decode(
-                            "utf-8"
-                        )
-                        if ext_content.strip() == config.parser_ext.strip():
-                            ext_id = ext["name"].split("/")[-1]
-                            self.client.activate_parser_extension(
-                                config.log_type, ext_id
+            if config.parser_ext is not None:
+                exts_response = self.client.list_parser_extensions(config.log_type)
+                if "parserExtensions" in exts_response:
+                    for ext in exts_response["parserExtensions"]:
+                        if ext.get("state") == ParserExtensionState.VALIDATED.value:
+                            ext_content = base64.b64decode(ext["cbnSnippet"]).decode(
+                                "utf-8"
                             )
-                            activated_count += 1
-                        else:
-                            LOGGER.warning(
-                                f"[{config.log_type}] Validated extension content mismatch. Skipping."
-                            )
-                        break  # Assume only one valid release candidate
+                            if ext_content.strip() == config.parser_ext.strip():
+                                ext_id = ext["name"].split("/")[-1]
+                                self.client.activate_parser_extension(
+                                    config.log_type, ext_id
+                                )
+                                activated_count += 1
+                            else:
+                                LOGGER.warning(
+                                    f"[{config.log_type}] Validated extension content mismatch. Skipping."
+                                )
+                            break  # Assume only one valid release candidate
         return activated_count
 
     def generate_events(self, target_log_type: str = None):


### PR DESCRIPTION
Better diff with `w=1`: https://github.com/GoogleCloudPlatform/secops-toolkit/pull/99/changes?w=1

I ran into this error while running the `activate-parsers` command:

```
$ python script/main.py activate-parsers
...
Traceback (most recent call last):
  File "/home/runner/work/chronicle-detection-tools/chronicle-detection-tools/parsers/script/main.py", line 206, in <module>
    cli()
    ~~~^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/click/core.py", line 1569, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/click/core.py", line 1490, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/click/core.py", line 1970, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/click/core.py", line 1353, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/click/core.py", line 907, in invoke
    return callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/click/decorators.py", line 46, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/runner/work/chronicle-detection-tools/chronicle-detection-tools/parsers/script/main.py", line 89, in activate_parsers
    count = manager.activate_all_passed()
  File "/home/runner/work/chronicle-detection-tools/chronicle-detection-tools/parsers/script/parser_manager.py", line 443, in activate_all_passed
    if ext_content.strip() == config.parser_ext.strip():
                              ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```

This is because there was a parser extension in validation but I didn't specify the extension in code. This could happen in the following scenario:
1. PR 1 introduces a parser extension for log type A
2. This creates a parser extension in the validated state
3. PR 2 is created making changes to another log type B
4. PR 2 is merged
5. The job for PR 2 fails because the repo doesn't have code for the parser extension yet

Feels like a simple fix to only attempt activating parser extensions if there is one defined in the code - again, hope I'm not making any wrong assumptions! Feel free to correct me if so! 